### PR TITLE
[CHEF-3497] Optionally Separate Default Values from User-Supplied Values

### DIFF
--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -57,7 +57,7 @@ describe Mixlib::CLI do
     end
   end
 
-  describe "instance methods" do
+  context "when configured with default single-config-hash behavior" do
 
     before(:each) do
       @cli = TestCLI.new
@@ -212,6 +212,27 @@ describe Mixlib::CLI do
         @cli.parse_options([ '-p', 'opscode', 'hard' ]).should == ['hard']
       end
     end
+  end
+
+  context "when configured to separate default options" do
+    before do
+      TestCLI.use_separate_default_options true
+      TestCLI.option(:defaulter, :short => "-D SOMETHING", :default => "this is the default")
+      @cli = TestCLI.new
+    end
+
+    it "sets default values on the `default` hash" do
+      @cli.parse_options([])
+      @cli.default_config[:defaulter].should == "this is the default"
+      @cli.config[:defaulter].should be_nil
+    end
+
+    it "sets parsed values on the `config` hash" do
+      @cli.parse_options(%w[-D not-default])
+      @cli.default_config[:defaulter].should == "this is the default"
+      @cli.config[:defaulter].should == "not-default"
+    end
+
   end
 
 end


### PR DESCRIPTION
This contributes to the fix for an issue with knife plugins when a `:default` value is specified via the mixlib-cli DSL.

The desired order of application for settings is:
1. defaults
2. config file
3. CLI options

Currently, mixlib-cli merges CLI options on top of defaults. This is problematic because programs such as knife need to parse the command line options in order to select the correct config file to use.

With this patch, defaults can be kept separate, so that the command line options can be parsed (in order to select the correct config file) and then settings can be merged in the desired order.

Also note that the new behavior must be opt-in, or else existing programs using mixlib-cli (without a pessimistic dependency--this includes chef) would break.
