### PR TITLE
Avoid ruby-warning "instance variable @{ivar} not initialized"

### DIFF
--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -47,7 +47,7 @@ module Mixlib
       end
 
       def use_separate_defaults?
-        @separate_default_options || false
+        @separate_default_options ||= false
       end
 
       # Add a command line option.


### PR DESCRIPTION
Example of reproduction
- `$VERBOSE = true`
- `ruby -w` 
