### PR TITLE
[MIXLIB-30] Malachheb 1.4.0

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -19,7 +19,7 @@ Mixlib::CLI provides a class-based command line option parsing object, like the 
       :long  => "--log_level LEVEL",
       :description => "Set the log level (debug, info, warn, error, fatal)",
       :required => true,
-	  :in => ['debug', 'info', 'warn', 'error', 'fatal']
+      :in => ['debug', 'info', 'warn', 'error', 'fatal']
       :proc => Proc.new { |l| l.to_sym }
       
     option :help,

--- a/README.rdoc
+++ b/README.rdoc
@@ -19,6 +19,7 @@ Mixlib::CLI provides a class-based command line option parsing object, like the 
       :long  => "--log_level LEVEL",
       :description => "Set the log level (debug, info, warn, error, fatal)",
       :required => true,
+	  :in => ['debug', 'info', 'warn', 'error', 'fatal']
       :proc => Proc.new { |l| l.to_sym }
       
     option :help,
@@ -71,6 +72,7 @@ Available arguments to 'option':
 :show_options:: If you want the option list printed when this option is called, set this to true.
 :exit:: Exit your program with the exit code when this option is specified. Example: 0
 :proc:: If set, the configuration value will be set to the return value of this proc.
+:in:: An array contain the list of accepted values
 
 === New in 1.2.2
 

--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -234,15 +234,13 @@ module Mixlib
           puts @opt_parser
           exit 2
         end
-        if opt_value[:in] 
+        if opt_value[:in]
           unless opt_value[:in].kind_of?(Array)
-            raise(ArgumentError, "Options config key :in must recieve an Array")
-            puts @opt_parser
-            exit 2
+            raise(ArgumentError, "Options config key :in must receive an Array")
           end
           if !opt_value[:in].include?(config[opt_key])
             reqarg = opt_value[:short] || opt_value[:long]
-            puts "#{reqarg}: #{config[opt_key]} is not included in the list #{opt_value[:in]}"
+            puts "#{reqarg}: #{config[opt_key]} is not included in the list ['#{opt_value[:in].join("', '")}'] "
             puts @opt_parser
             exit 2
           end

--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -173,6 +173,7 @@ module Mixlib
         config_opts[:proc] ||= nil
         config_opts[:show_options] ||= false
         config_opts[:exit] ||= nil
+        config_opts[:in] ||= nil
 
         if config_opts.has_key?(:default)
           defaults_container[config_key] = config_opts[:default]
@@ -233,6 +234,19 @@ module Mixlib
           puts @opt_parser
           exit 2
         end
+        if opt_value[:in] 
+          unless opt_value[:in].kind_of?(Array)
+            raise(ArgumentError, "Options config key :in must recieve an Array")
+            puts @opt_parser
+            exit 2
+          end
+          if !opt_value[:in].include?(config[opt_key])
+            reqarg = opt_value[:short] || opt_value[:long]
+            puts "#{reqarg}: #{config[opt_key]} is not included in the list #{opt_value[:in]}"
+            puts @opt_parser
+            exit 2
+          end
+        end
       end
 
       argv
@@ -243,10 +257,10 @@ module Mixlib
 
       arguments << opt_setting[:short] if opt_setting.has_key?(:short)
       arguments << opt_setting[:long] if opt_setting.has_key?(:long)
-
       if opt_setting.has_key?(:description)
         description = opt_setting[:description]
         description << " (required)" if opt_setting[:required]
+        description << " (included in #{opt_setting[:in]})" if opt_setting[:in]
         arguments << description
       end
 

--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -265,7 +265,7 @@ module Mixlib
       if opt_setting.has_key?(:description)
         description = opt_setting[:description]
         description << " (required)" if opt_setting[:required]
-        description << " (included in #{opt_setting[:in]})" if opt_setting[:in]
+        description << " (included in ['#{opt_setting[:in].join("', '")}'])" if opt_setting[:in]
         arguments << description
       end
 

--- a/mixlib-cli.gemspec
+++ b/mixlib-cli.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   # Uncomment this to add a dependency
   #s.add_dependency "mixlib-log"
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'rdoc'
   
   s.require_path = 'lib'

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -175,26 +175,26 @@ describe Mixlib::CLI do
         @cli = TestCLI.new
         lambda { @cli.parse_options([]) }.should raise_error(SystemExit)
       end
-      
+
       it "should exit if option is not included in the list" do
         TestCLI.option(:inclusion, :short => "-i val", :in => ['one', 'two'])
         @cli = TestCLI.new
         lambda { @cli.parse_options(['-i', 'three']) }.should raise_error(SystemExit)
       end
-      
-      it "should exit if options key :in is not an array" do
+
+      it "should raise ArgumentError if options key :in is not an array" do
         TestCLI.option(:inclusion, :short => "-i val", :in => 'foo')
         @cli = TestCLI.new
         lambda { @cli.parse_options(['-i', 'three']) }.should raise_error(ArgumentError)
       end
-      
+
       it "should not exit if option is included in the list" do
         TestCLI.option(:inclusion, :short => "-i val", :in => ['one', 'two'])
         @cli = TestCLI.new
         @cli.parse_options(['-i', 'one'])
         @cli.config[:inclusion].should == 'one'
       end
-      
+
       it "should change description if :in key is specified" do
         TestCLI.option(:inclusion, :short => "-i val", :in => ['one', 'two'], :description => 'desc')
         @cli = TestCLI.new

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -79,7 +79,8 @@ describe Mixlib::CLI do
             :required => false,
             :proc => nil,
             :show_options => false,
-            :exit => nil
+            :exit => nil,
+            :in => nil
           }
         }
       end
@@ -173,6 +174,32 @@ describe Mixlib::CLI do
         TestCLI.option(:require_me, :short => "-r", :boolean => true, :required => true)
         @cli = TestCLI.new
         lambda { @cli.parse_options([]) }.should raise_error(SystemExit)
+      end
+      
+      it "should exit if option is not included in the list" do
+        TestCLI.option(:inclusion, :short => "-i val", :in => ['one', 'two'])
+        @cli = TestCLI.new
+        lambda { @cli.parse_options(['-i', 'three']) }.should raise_error(SystemExit)
+      end
+      
+      it "should exit if options key :in is not an array" do
+        TestCLI.option(:inclusion, :short => "-i val", :in => 'foo')
+        @cli = TestCLI.new
+        lambda { @cli.parse_options(['-i', 'three']) }.should raise_error(ArgumentError)
+      end
+      
+      it "should not exit if option is included in the list" do
+        TestCLI.option(:inclusion, :short => "-i val", :in => ['one', 'two'])
+        @cli = TestCLI.new
+        @cli.parse_options(['-i', 'one'])
+        @cli.config[:inclusion].should == 'one'
+      end
+      
+      it "should change description if :in key is specified" do
+        TestCLI.option(:inclusion, :short => "-i val", :in => ['one', 'two'], :description => 'desc')
+        @cli = TestCLI.new
+        @cli.parse_options(['-i', 'one'])
+        @cli.options[:inclusion][:description].should == "desc (included in [\"one\", \"two\"])"
       end
 
       it "should not exit if a required option is specified" do

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -198,7 +198,7 @@ describe Mixlib::CLI do
         TestCLI.option(:inclusion, :short => "-i val", :in => ['one', 'two'], :description => 'desc')
         @cli = TestCLI.new
         @cli.parse_options(['-i', 'one'])
-        @cli.options[:inclusion][:description].should == "desc (included in [\"one\", \"two\"])"
+        @cli.options[:inclusion][:description].should == "desc (included in ['one', 'two'])"
       end
 
       it "should not exit if a required option is specified" do


### PR DESCRIPTION
I added the argument 'in' to specify the valid values ​​of an option like this : 

    option :log_level,
      :description => "Set the log level (debug, info, warn, error, fatal)",
      :in => ['debug', 'info', 'warn', 'error', 'fatal']

I think this feature is important for some options,
Thanks.