### PR TITLE
Support two-argument procs for reducer style.

### DIFF
--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -281,7 +281,18 @@ module Mixlib
 
           parse_block =
             Proc.new() do |c|
-              config[opt_key] = (opt_val[:proc] && opt_val[:proc].call(c)) || c
+              config[opt_key] = if opt_val[:proc]
+                if opt_val[:proc].arity == 2
+                  # New hotness to allow for reducer-style procs.
+                  opt_val[:proc].call(c, config[opt_key])
+                else
+                  # Older single-argument proc.
+                  opt_val[:proc].call(c)
+                end
+              else
+                # No proc.
+                c
+              end
               puts opts if opt_val[:show_options]
               exit opt_val[:exit] if opt_val[:exit]
             end

--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -282,17 +282,17 @@ module Mixlib
           parse_block =
             Proc.new() do |c|
               config[opt_key] = if opt_val[:proc]
-                if opt_val[:proc].arity == 2
-                  # New hotness to allow for reducer-style procs.
-                  opt_val[:proc].call(c, config[opt_key])
-                else
-                  # Older single-argument proc.
-                  opt_val[:proc].call(c)
-                end
-              else
-                # No proc.
-                c
-              end
+                                  if opt_val[:proc].arity == 2
+                                    # New hotness to allow for reducer-style procs.
+                                    opt_val[:proc].call(c, config[opt_key])
+                                  else
+                                    # Older single-argument proc.
+                                    opt_val[:proc].call(c)
+                                  end
+                                else
+                                  # No proc.
+                                  c
+                                end
               puts opts if opt_val[:show_options]
               exit opt_val[:exit] if opt_val[:exit]
             end

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -149,6 +149,16 @@ describe Mixlib::CLI do
         @cli.config[:number].should == 4
       end
 
+      it "should pass the existing value to two-argument procs" do
+        TestCLI.option(:number,
+          :short => "-n NUMBER",
+          :proc => Proc.new { |value, existing| existing ||= []; existing << value; existing }
+        )
+        @cli = TestCLI.new
+        @cli.parse_options([ "-n", "2", "-n", "3" ])
+        @cli.config[:number].should == ["2", "3"]
+      end
+
       it "should set the corresponding config value to true for boolean arguments" do
         TestCLI.option(:i_am_boolean, :short => "-i", :boolean => true)
         @cli = TestCLI.new

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -156,7 +156,7 @@ describe Mixlib::CLI do
         )
         @cli = TestCLI.new
         @cli.parse_options([ "-n", "2", "-n", "3" ])
-        @cli.config[:number].should == ["2", "3"]
+        @cli.config[:number].should == %w{2 3}
       end
 
       it "should set the corresponding config value to true for boolean arguments" do


### PR DESCRIPTION
This allows CLI options which can be repeated where the final value is an array or a hash of some kind. Switching on arity is kind of gross, I could rewrite this to use a different key than `:proc` if that sounds better.