### PR TITLE
Avoid modification on possibly frozen string

### DIFF
--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -311,9 +311,10 @@ module Mixlib
       arguments << opt_setting[:short] if opt_setting.has_key?(:short)
       arguments << opt_setting[:long] if opt_setting.has_key?(:long)
       if opt_setting.has_key?(:description)
-        description = opt_setting[:description]
+        description = opt_setting[:description].dup
         description << " (required)" if opt_setting[:required]
         description << " (included in ['#{opt_setting[:in].join("', '")}'])" if opt_setting[:in]
+        opt_setting[:description] = description
         arguments << description
       end
 


### PR DESCRIPTION
Most users are defining option description with string literal. Starting from ruby 2.3, rubocop starts advocating to set `# frozen_string_literal: true` magic comment.

Before this patch, this would raise an error related to modification of frozen string.