### PR TITLE
bugfix: if param :required is set to false and param :in is set the option is required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pkg
 .bundle
 Gemfile.lock
 vendor
+.idea/
+.ruby-version

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require "rubygems"
 require "rubygems/package_task"
 require "rdoc/task"
 require "rspec/core/rake_task"
+require "mixlib/cli/version"
 
 Bundler::GemHelper.install_tasks
 
@@ -13,11 +14,9 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = "spec/**/*_spec.rb"
 end
 
-gem_spec = eval(File.read("mixlib-cli.gemspec"))
-
 RDoc::Task.new do |rdoc|
   rdoc.rdoc_dir = "rdoc"
-  rdoc.title = "mixlib-cli #{gem_spec.version}"
+  rdoc.title = "mixlib-cli #{Mixlib::CLI::VERSION}"
   rdoc.rdoc_files.include("README*")
   rdoc.rdoc_files.include("lib/**/*.rb")
 end

--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -241,7 +241,7 @@ module Mixlib
           unless opt_value[:in].kind_of?(Array)
             raise(ArgumentError, "Options config key :in must receive an Array")
           end
-          if !opt_value[:in].include?(config[opt_key])
+          if config[opt_key] && !opt_value[:in].include?(config[opt_key])
             reqarg = opt_value[:short] || opt_value[:long]
             puts "#{reqarg}: #{config[opt_key]} is not included in the list ['#{opt_value[:in].join("', '")}'] "
             puts @opt_parser

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -185,27 +185,47 @@ describe Mixlib::CLI do
         expect(lambda { @cli.parse_options([]) }).to raise_error(SystemExit)
       end
 
-      it "exits if option is not included in the list" do
-        TestCLI.option(:inclusion, :short => "-i val", :in => %w{one two})
+      it "exits if option is not included in the list and required" do
+        TestCLI.option(:inclusion, :short => "-i val", :in => %w{one two}, :required => true)
         @cli = TestCLI.new
         expect(lambda { @cli.parse_options(["-i", "three"]) }).to raise_error(SystemExit)
       end
 
+      it "exits if option is not included in the list and not required" do
+        TestCLI.option(:inclusion, :short => "-i val", :in => %w{one two}, :required => false)
+        @cli = TestCLI.new
+        expect(lambda { @cli.parse_options(["-i", "three"]) }).to raise_error(SystemExit)
+      end
+
+      it "doesn't exit if option is nil and not required" do
+        TestCLI.option(:inclusion, :short => "-i val", :in => %w{one two}, :required => false)
+        @cli = TestCLI.new
+        expect do
+          expect(@cli.parse_options([])).to eql []
+        end.to_not raise_error
+      end
+
+      it "exit if option is nil and required" do
+        TestCLI.option(:inclusion, :short => "-i val", :in => %w{one two}, :required => true)
+        @cli = TestCLI.new
+        expect(lambda { @cli.parse_options([]) }).to raise_error(SystemExit)
+      end
+
       it "raises ArgumentError if options key :in is not an array" do
-        TestCLI.option(:inclusion, :short => "-i val", :in => "foo")
+        TestCLI.option(:inclusion, :short => "-i val", :in => "foo", :required => true)
         @cli = TestCLI.new
         expect(lambda { @cli.parse_options(["-i", "three"]) }).to raise_error(ArgumentError)
       end
 
       it "doesn't exit if option is included in the list" do
-        TestCLI.option(:inclusion, :short => "-i val", :in => %w{one two})
+        TestCLI.option(:inclusion, :short => "-i val", :in => %w{one two}, :required => true)
         @cli = TestCLI.new
         @cli.parse_options(["-i", "one"])
         expect(@cli.config[:inclusion]).to eql("one")
       end
 
       it "changes description if :in key is specified" do
-        TestCLI.option(:inclusion, :short => "-i val", :in => %w{one two}, :description => "desc")
+        TestCLI.option(:inclusion, :short => "-i val", :in => %w{one two}, :description => "desc", :required => false)
         @cli = TestCLI.new
         @cli.parse_options(["-i", "one"])
         expect(@cli.options[:inclusion][:description]).to eql("desc (included in ['one', 'two'])")


### PR DESCRIPTION
in my code I use
```
  option :metric,
         description: 'Metric to fetch',
         short: '-m METRIC',
         long: '--metric',
         required: false,
         in: %w[AllowedRequests BlockedRequests CountedRequests PassedRequests]
```
when I try to run my code I will recieve 
```
bundle exec metrics-cloudfront.rb
-m METRIC:  is not included in the list ['Requests', 'BytesDownloaded', 'BytesUploaded', 'TotalErrorRate', '4xxErrorRate', '5xxErrorRate'] 
```
This PR fixed this problem
