### PR TITLE
Don't ship the test files in the gem artifact

### DIFF
--- a/mixlib-cli.gemspec
+++ b/mixlib-cli.gemspec
@@ -4,15 +4,13 @@ require "mixlib/cli/version"
 Gem::Specification.new do |s|
   s.name = "mixlib-cli"
   s.version = Mixlib::CLI::VERSION
-  s.extra_rdoc_files = ["README.md", "LICENSE", "NOTICE"]
   s.summary = "A simple mixin for CLI interfaces, including option parsing"
   s.description = s.summary
   s.author = "Chef Software, Inc."
   s.email = "info@chef.io"
-  s.homepage = "https://www.chef.io"
+  s.homepage = "https://www.github.com/mixlib-cli"
   s.license = "Apache-2.0"
 
   s.require_path = "lib"
-  s.files = %w{LICENSE README.md Gemfile Rakefile NOTICE} + Dir.glob("*.gemspec") +
-    Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
+  s.files = %w{LICENSE NOTICE} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
 end


### PR DESCRIPTION
Skip the Readme, Gemfile, Rakefile, Gemspec, and spec files as they aren't
needed by the installed artifact.

Signed-off-by: Tim Smith <tsmith@chef.io>