### PR TITLE
update travis, drop ruby < 2.5, major version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
-sudo: false
 language: ruby
 cache: bundler
+dist: xenial
 
+before_install:
+  - gem install bundler
+  - bundle --version
+  - gem update --system
+  - gem --version
 matrix:
   include:
-    - rvm: 2.2.10
-    - rvm: 2.3.7
-    - rvm: 2.4.4
-    - rvm: 2.5.1
+    - rvm: 2.5.3
+    - rvm: 2.6.0
     - rvm: ruby-head
   allow_failures:
     - rvm: ruby-head

--- a/lib/mixlib/cli/version.rb
+++ b/lib/mixlib/cli/version.rb
@@ -1,5 +1,5 @@
 module Mixlib
   module CLI
-    VERSION = "1.7.6".freeze
+    VERSION = "2.0.0".freeze
   end
 end

--- a/mixlib-cli.gemspec
+++ b/mixlib-cli.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.email = "info@chef.io"
   s.homepage = "https://www.chef.io"
   s.license = "Apache-2.0"
+  s.required_ruby_version = ">= 2.5"
 
   s.require_path = "lib"
   s.files = %w{LICENSE README.md Gemfile Rakefile NOTICE} + Dir.glob("*.gemspec") +


### PR DESCRIPTION
solely major version bump for the ruby support floor
