### PR TITLE
fix global state pollution issues across examples

### DIFF
--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,6 @@ $:.push File.join(File.dirname(__FILE__), "..", "lib")
 
 require "mixlib/cli"
 
-class TestCLI
-  include Mixlib::CLI
-end
-
 RSpec.configure do |config|
   # Use documentation format
   config.formatter = "doc"
@@ -23,4 +19,12 @@ RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
   config.warnings = true
+
+  config.before(:each) do
+    # create a fresh TestCLI class on every example, so that examples never
+    # pollute global variables and create ordering issues
+    Object.send(:remove_const, "TestCLI") if Object.const_defined?("TestCLI")
+    TestCLI = Class.new
+    TestCLI.send(:include, Mixlib::CLI)
+  end
 end


### PR DESCRIPTION
since classes are global state, having a single TestCLI class that
threads through all the examples creates state pollution that can
cause ordering problems.

solve this by rewiring TestCLI to a new class every single time.
