### PR TITLE
Add back support for Ruby 2.4

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -16,6 +16,8 @@ github:
   # allow bumping the minor release via label
   minor_bump_labels:
     - "Expeditor: Bump Version Minor"
+  mmajor_bump_labels:
+    - "Expeditor: Bump Version Major"
 
 changelog:
   rollup_header: Changes not yet released to rubygems.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ before_install:
   - gem --version
 matrix:
   include:
-    - rvm: 2.5.3
-    - rvm: 2.6.0
+    - rvm: 2.4.5
+    - rvm: 2.5.5
+    - rvm: 2.6.2
     - rvm: ruby-head
   allow_failures:
     - rvm: ruby-head

--- a/mixlib-cli.gemspec
+++ b/mixlib-cli.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email = "info@chef.io"
   s.homepage = "https://www.github.com/mixlib-cli"
   s.license = "Apache-2.0"
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 2.4"
 
   s.require_path = "lib"
   s.files = %w{LICENSE NOTICE} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }


### PR DESCRIPTION
This allows us to use this on Chef 14 and Chef 15 and simplifies our
maint for the next year.

Signed-off-by: Tim Smith <tsmith@chef.io>