### PR TITLE
Improve the --help text output of 'in:'

### DIFF
--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -313,7 +313,7 @@ module Mixlib
       if opt_setting.key?(:description)
         description = opt_setting[:description].dup
         description << " (required)" if opt_setting[:required]
-        description << " (included in ['#{opt_setting[:in].join("', '")}'])" if opt_setting[:in]
+        description << " (valid options are: ['#{opt_setting[:in].join("', '")}'])" if opt_setting[:in]
         opt_setting[:description] = description
         arguments << description
       end

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -228,7 +228,7 @@ describe Mixlib::CLI do
         TestCLI.option(:inclusion, short: "-i val", in: %w{one two}, description: "desc", required: false)
         @cli = TestCLI.new
         @cli.parse_options(["-i", "one"])
-        expect(@cli.options[:inclusion][:description]).to eql("desc (included in ['one', 'two'])")
+        expect(@cli.options[:inclusion][:description]).to eql("desc (valid options are: ['one', 'two'])")
       end
 
       it "doesn't exit if a required option is specified" do


### PR DESCRIPTION
The automatic addition of the 'in' options to the --help output could be
more clear about what the list is.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>