### PR TITLE
Print out human readable lists of allowed CLI options

### DIFF
--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2008-2019 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -243,7 +243,7 @@ module Mixlib
           end
           if config[opt_key] && !opt_value[:in].include?(config[opt_key])
             reqarg = opt_value[:short] || opt_value[:long]
-            puts "#{reqarg}: #{config[opt_key]} is not included in the list ['#{opt_value[:in].join("', '")}'] "
+            puts "#{reqarg}: #{config[opt_key]} is not one of the allowed values: #{friendly_opt_list(opt_value[:in])}"
             puts @opt_parser
             exit 2
           end
@@ -313,12 +313,22 @@ module Mixlib
       if opt_setting.key?(:description)
         description = opt_setting[:description].dup
         description << " (required)" if opt_setting[:required]
-        description << " (valid options are: ['#{opt_setting[:in].join("', '")}'])" if opt_setting[:in]
+        description << " (valid options: #{friendly_opt_list(opt_setting[:in])})" if opt_setting[:in]
         opt_setting[:description] = description
         arguments << description
       end
 
       arguments
+    end
+
+    # @private
+    # @param opt_arry [Array]
+    #
+    # @return [String] a friendly quoted list of items complete with "and"
+    def friendly_opt_list(opt_array)
+      opts = opt_array.map { |x| "'#{x}'" }
+      return opts.join(" and ") if opts.size < 3
+      opts[0..-2].join(", ") + " and " + opts[-1]
     end
 
     def self.included(receiver)

--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -324,11 +324,11 @@ module Mixlib
     # @private
     # @param opt_arry [Array]
     #
-    # @return [String] a friendly quoted list of items complete with "and"
+    # @return [String] a friendly quoted list of items complete with "or"
     def friendly_opt_list(opt_array)
       opts = opt_array.map { |x| "'#{x}'" }
-      return opts.join(" and ") if opts.size < 3
-      opts[0..-2].join(", ") + " and " + opts[-1]
+      return opts.join(" or ") if opts.size < 3
+      opts[0..-2].join(", ") + ", or " + opts[-1]
     end
 
     def self.included(receiver)

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -224,17 +224,25 @@ describe Mixlib::CLI do
         expect(@cli.config[:inclusion]).to eql("one")
       end
 
-      it "changes description if :in key is specified" do
+      it "changes description if :in key is specified with a single value" do
+        TestCLI.option(:inclusion, short: "-i val", in: %w{one}, description: "desc", required: false)
+        @cli = TestCLI.new
+        @cli.parse_options(["-i", "one"])
+        expect(@cli.options[:inclusion][:description]).to eql("desc (valid options: 'one')")
+      end
+
+      it "changes description if :in key is specified with 2 values" do
         TestCLI.option(:inclusion, short: "-i val", in: %w{one two}, description: "desc", required: false)
         @cli = TestCLI.new
         @cli.parse_options(["-i", "one"])
-        expect(@cli.options[:inclusion][:description]).to eql("desc (valid options: 'one' and 'two')")
+        expect(@cli.options[:inclusion][:description]).to eql("desc (valid options: 'one' or 'two')")
       end
 
-      it "Raises SystemExit when the provided value is not a member of the :in array" do
-        TestCLI.option(:inclusion, short: "-i val", in: %w{one two}, description: "desc", required: false)
+      it "changes description if :in key is specified with 3 values" do
+        TestCLI.option(:inclusion, short: "-i val", in: %w{one two three}, description: "desc", required: false)
         @cli = TestCLI.new
-        expect(lambda { @cli.parse_options(["-i", "three"]) }).to raise_error(SystemExit)
+        @cli.parse_options(["-i", "one"])
+        expect(@cli.options[:inclusion][:description]).to eql("desc (valid options: 'one', 'two', or 'three')")
       end
 
       it "doesn't exit if a required option is specified" do

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -228,7 +228,13 @@ describe Mixlib::CLI do
         TestCLI.option(:inclusion, short: "-i val", in: %w{one two}, description: "desc", required: false)
         @cli = TestCLI.new
         @cli.parse_options(["-i", "one"])
-        expect(@cli.options[:inclusion][:description]).to eql("desc (valid options are: ['one', 'two'])")
+        expect(@cli.options[:inclusion][:description]).to eql("desc (valid options: 'one' and 'two')")
+      end
+
+      it "Raises SystemExit when the provided value is not a member of the :in array" do
+        TestCLI.option(:inclusion, short: "-i val", in: %w{one two}, description: "desc", required: false)
+        @cli = TestCLI.new
+        expect(lambda { @cli.parse_options(["-i", "three"]) }).to raise_error(SystemExit)
       end
 
       it "doesn't exit if a required option is specified" do


### PR DESCRIPTION
Give a nice friendly sentence and not an array. This uses the code we nuked from chef/chef that did the same.

Signed-off-by: Tim Smith <tsmith@chef.io>