### PR TITLE
Don't explode when there are unknown keys in 'config'

### DIFF
--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -392,11 +392,16 @@ module Mixlib
       merge_in_values = {}
       config.each_key do |opt_key|
         opt_cfg = options[opt_key]
+
         # Deprecated entries do not have defaults so no matter what
         # separate_default_options are set, if we see a 'config'
         # entry that contains a deprecated indicator, then the option was
         # explicitly provided by the caller.
-        next unless opt_cfg[:deprecated]
+        #
+        # opt_cfg may not exist if an inheriting application
+        # has directly inserted values info config.
+        next unless opt_cfg && opt_cfg[:deprecated]
+
         replacement_key = opt_cfg[:replacement]
         if replacement_key
           # This is the value passed into the deprecated flag. We'll use

--- a/spec/mixlib/cli_spec.rb
+++ b/spec/mixlib/cli_spec.rb
@@ -326,6 +326,18 @@ describe Mixlib::CLI do
           TestCLI.option(:option_c, short: "-c ARG")
         end
 
+        context "when someone injects an unexpected value into 'config'" do
+          before do
+            cli.config[:surprise] = true
+          end
+          it "parses and preserves both known and unknown config values" do
+            cli.parse_options(%w{--option-a})
+            expect(cli.config[:surprise]).to eql true
+            expect(cli.config[:option_a]).to eql true
+          end
+
+        end
+
         context "when the deprecated option has a replacement" do
 
           context "and a value_mapper is provided" do


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
Update handle_deprecated_options to be graceful when
'config' has been modified externally to contain unknown keys.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
