### PR TITLE
Speed up Buildkite tests

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -2,27 +2,27 @@ steps:
 
 - label: run-lint-and-specs-ruby-2.4
   command:
-    - asdf local ruby 2.4.5
-    - bundle install --jobs=7 --retry=3
+    - bundle install --jobs=7 --retry=3 --without docs debug
     - bundle exec rake
   expeditor:
     executor:
       docker:
+        image: ruby:2.4-stretch
 
 - label: run-lint-and-specs-ruby-2.5
   command:
-    - asdf local ruby 2.5.5
-    - bundle install --jobs=7 --retry=3
+    - bundle install --jobs=7 --retry=3 --without docs debug
     - bundle exec rake
   expeditor:
     executor:
       docker:
+        image: ruby:2.5-stretch
 
 - label: run-lint-and-specs-ruby-2.6
   command:
-    - asdf local ruby 2.6.3
-    - bundle install --jobs=7 --retry=3
+    - bundle install --jobs=7 --retry=3 --without docs debug
     - bundle exec rake
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-stretch

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*                 @chef/chef-infra-reviewers
+*                 @chef/chef-foundation-reviewers
 .expeditor/**     @chef/jex-team
 *.md              @chef/docs-team

--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ group :docs do
 end
 
 group :test do
-  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
+  gem "chefstyle"
   gem "rspec", "~> 3.0"
   gem "rake"
 end
 
-group :development do
+group :debug do
   gem "pry"
   gem "pry-byebug"
   gem "pry-stack_explorer"


### PR DESCRIPTION
Use the smaller containers, skip gems we don't need and use chefstyle from rubygems.

Signed-off-by: Tim Smith <tsmith@chef.io>