### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/mixlib/cli.rb
+++ b/lib/mixlib/cli.rb
@@ -17,7 +17,7 @@
 #
 
 require "optparse"
-require "mixlib/cli/formatter"
+require_relative "cli/formatter"
 module Mixlib
 
   # == Mixlib::CLI


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>