### PR TITLE
Bump mixlib-cli to use at least 2.7 to fix tests

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -6,13 +6,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6
 - label: run-lint-and-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/mixlib-cli.gemspec
+++ b/mixlib-cli.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email = "info@chef.io"
   s.homepage = "https://github.com/chef/mixlib-cli"
   s.license = "Apache-2.0"
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.7"
 
   s.require_path = "lib"
   s.files = %w{LICENSE NOTICE} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }


### PR DESCRIPTION
Bump mixlib-cli to use at least 2.7 to fix tests

Signed-off-by: Phil Dibowitz <phil@ipom.com>
