### PR TITLE
Drop rubocop-ast pin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem "chefstyle"
   gem "rake"
   gem "rspec", "~> 3.0"
-  gem "rubocop-ast", "~> 1.4.1" # Drop this dependency/version when we remove ruby-2.4 support
+  gem "rubocop-ast"
 end
 
 group :debug do


### PR DESCRIPTION
Pin was only needed for Ruby 2.4

Signed-off-by: Phil Dibowitz <phil@ipom.com>
